### PR TITLE
Added license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 liorwohl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Thank you for this package!
I just noticed that the license is missing from this project.
It was forked from https://github.com/jcgertig/date-input-polyfill which is licensed under the MIT license, which states:
```
The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
```

Heres the fork history:
1. https://github.com/liorwohl/html5-simple-date-input-polyfill (orginal license MIT)
2. https://github.com/brianblakely/nodep-date-input-polyfill (same license)
4. https://github.com/jcgertig/date-input-polyfill (same license)
4. https://github.com/KreutzerCode/configurable-date-input-polyfill (license missing)