### PR TITLE
Reporting Issue: Does not work at all with Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     The last date-input polyfill you will ever need. A fancy and lightweight datepicker with a high number of configuration options for all needs. Supports any calendar format and contains a large amount of localizations.
 </p>
 
-Just include this simple script and IE, Firefox, and OS X Safari will support `<input type="date">`, without any dependencies, not even jQuery!
+Just include this simple script and IE and Firefox will support `<input type="date">`, without any dependencies, not even jQuery!
 
 Forked from [date-input-polyfill](https://github.com/jcgertig/date-input-polyfill). Continuing as a separate project.
 
@@ -110,7 +110,6 @@ include it anywhere in your HTML.
 ## Browser support
 #### Desktop
 * Chrome
-* Safari
 * Firefox
 * Opera
 * Edge


### PR DESCRIPTION
Issues are unfortunately disabled for this repository. Hence my issue as a pull request. It is definitely the case that this package does not work at all with Safari. Sorry, hence the adjustment in the README.

Demo in latest Chrome:
![Chrome](https://user-images.githubusercontent.com/640639/142586831-8c9ebc0f-69ac-4fae-a70b-56272aadc4c9.png)

Demo in Safari Version 11.0.3 (13604.5.6)
![Safari](https://user-images.githubusercontent.com/640639/142586848-3b147c56-022e-412d-b2b3-5202577430aa.png)

If Safari on MacOS is supported in a newer version though, then it would be very helpful to specify the minimum version in the README.

see also https://github.com/JohannesHoppe/angular-date-value-accessor/issues/22